### PR TITLE
Update the README to suggest constructor-based DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@
 * Create a `PollController` class in the `controller` sub package.
 	* `PollController` signature should be `annotated` with `@RestController`
 
-* `PollController` has a `pollRepository` instance variable of type `PollRepository`
-	* `pollRepository` should be `annotated` with `@Inject`
+* `PollController` has a `pollRepository` instance variable of type `PollRepository`  
+
+* Create a constructor that accepts a `PollRepository` argument and assigns its value to the `pollRepository` member variable.  
+	* Mark the constructor with the `@Autowired` annotation.
 
 
 ### Part 3.1.1 - Create `GET` request method
@@ -273,8 +275,13 @@ public ResponseEntity<?> deletePoll(@PathVariable Long pollId) {
 ```java
 @RestController
 public class VoteController {
-    @Inject
+
     private VoteRepository voteRepository;
+    
+    @Autowired
+    public VoteController(VoteRepository voteRepository) {
+    	this.voteRepository = voteRepository;
+    }
 
     @RequestMapping(value = "/polls/{pollId}/votes", method = RequestMethod.POST)
     public ResponseEntity<?> createVote(@PathVariable Long pollId, @RequestBody Vote
@@ -414,8 +421,13 @@ public class VoteResult {
 ```java
 @RestController
 public class ComputeResultController {
-    @Inject
+    
     private VoteRepository voteRepository;
+    
+    @Autowired
+    public ComputeResultController(VoteRepository voteRepository) {
+    	this.voteRepository = voteRepository;
+    }
 
     @RequestMapping(value = "/computeresult", method = RequestMethod.GET)
     public ResponseEntity<?> computeResult(@RequestParam Long pollId) {


### PR DESCRIPTION
Constructor-based DI asserts that the class cannot
be instantiated without the supplied dependency. This method
enforces the requirement whether or not you use Spring, and
therefore is container-agnostic.

Also, Spring will throw up a Warning flag if you just annotate
the prop with @Inject